### PR TITLE
ci: update Go version and streamline CI configurations

### DIFF
--- a/.github/workflows/ci-kotlin.yml
+++ b/.github/workflows/ci-kotlin.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.3'
+          go-version: '1.22.2'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v4
@@ -23,4 +23,3 @@ jobs:
         working-directory: kotlin
       - run: sqlc diff
         working-directory: kotlin/examples
-

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.3'
+          go-version: '1.22.2'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.3'
+          go-version: '1.22.2'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         cgo: ['1', '0']
         # Workaround no native support for conditional matrix items
         # https://github.com/orgs/community/discussions/26253#discussioncomment-6745038
@@ -17,68 +17,68 @@ jobs:
         exclude:
           - isMain: false
         include:
-        - os: ubuntu-latest
-          cgo: '1'
-        - os: ubuntu-latest
-          cgo: '0'
+          - os: ubuntu-latest
+            cgo: '1'
+          - os: ubuntu-latest
+            cgo: '0'
     name: test ${{ matrix.os }} cgo=${{ matrix.cgo }}
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-        check-latest: true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
 
-    - name: install gotestsum
-      run: go install gotest.tools/gotestsum@latest
+      - name: install gotestsum
+        run: go install gotest.tools/gotestsum@latest
 
-    - name: install sqlc-gen-test
-      run: go install github.com/sqlc-dev/sqlc-gen-test@v0.1.0
+      - name: install sqlc-gen-test
+        run: go install github.com/sqlc-dev/sqlc-gen-test@v0.1.0
 
-    - name: install ./...
-      run: go install ./...
-      env:
-        CGO_ENABLED: ${{ matrix.cgo }}
+      - name: install ./...
+        run: go install ./...
+        env:
+          CGO_ENABLED: ${{ matrix.cgo }}
 
-    - name: build internal/endtoend
-      run: go build ./...
-      working-directory: internal/endtoend/testdata
-      env:
-        CGO_ENABLED: ${{ matrix.cgo }}
+      - name: build internal/endtoend
+        run: go build ./...
+        working-directory: internal/endtoend/testdata
+        env:
+          CGO_ENABLED: ${{ matrix.cgo }}
 
-    # Start a PostgreSQL server
-    - uses: sqlc-dev/action-setup-postgres@master
-      with:
-        postgres-version: "16"
-      id: postgres
+      # Start a PostgreSQL server
+      - uses: sqlc-dev/action-setup-postgres@master
+        with:
+          postgres-version: '16'
+        id: postgres
 
-    # Start a MySQL server
-    - uses: shogo82148/actions-setup-mysql@v1
-      with:
-        mysql-version: "8.1"
+      # Start a MySQL server
+      - uses: shogo82148/actions-setup-mysql@v1
+        with:
+          mysql-version: '8.1'
 
-    - name: test ./...
-      run: gotestsum --junitfile junit.xml -- --tags=examples -timeout 20m ./...
-      env:
-        CI_SQLC_PROJECT_ID: ${{ secrets.CI_SQLC_PROJECT_ID }}
-        CI_SQLC_AUTH_TOKEN: ${{ secrets.CI_SQLC_AUTH_TOKEN }}
-        SQLC_AUTH_TOKEN: ${{ secrets.CI_SQLC_AUTH_TOKEN }}
-        MYSQL_SERVER_URI: root:@tcp(localhost:3306)/mysql?multiStatements=true&parseTime=true
-        POSTGRESQL_SERVER_URI: ${{ steps.postgres.outputs.connection-uri }}?sslmode=disable
-        CGO_ENABLED: ${{ matrix.cgo }}
+      - name: test ./...
+        run: gotestsum --junitfile junit.xml -- --tags=examples -timeout 20m ./...
+        env:
+          CI_SQLC_PROJECT_ID: ${{ secrets.CI_SQLC_PROJECT_ID }}
+          CI_SQLC_AUTH_TOKEN: ${{ secrets.CI_SQLC_AUTH_TOKEN }}
+          SQLC_AUTH_TOKEN: ${{ secrets.CI_SQLC_AUTH_TOKEN }}
+          MYSQL_SERVER_URI: root:@tcp(localhost:3306)/mysql?multiStatements=true&parseTime=true
+          POSTGRESQL_SERVER_URI: ${{ steps.postgres.outputs.connection-uri }}?sslmode=disable
+          CGO_ENABLED: ${{ matrix.cgo }}
 
   vuln_check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.21.9'
-        # go-version-file: go.mod
-        # check-latest: true
-    - run: go install golang.org/x/vuln/cmd/govulncheck@latest
-    - run: govulncheck ./...
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+          # go-version-file: go.mod
+          # check-latest: true
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: govulncheck ./...

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -7,33 +7,32 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:15.0-alpine
+        image: postgres:16.2-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-        check-latest: true
-    - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
-    - run: mkdir -p gen/contrib
-    - run: ./sqlc-pg-gen gen
-      env:
-        PG_USER: postgres
-        PG_HOST: localhost
-        PG_DATABASE: postgres
-        PG_PASSWORD: postgres
-        PG_PORT: ${{ job.services.postgres.ports['5432'] }}
-    - name: Save results
-      uses: actions/upload-artifact@v4
-      with:
-        name: sqlc-pg-gen-results
-        path: gen
-
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+      - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
+      - run: mkdir -p gen/contrib
+      - run: ./sqlc-pg-gen gen
+        env:
+          PG_USER: postgres
+          PG_HOST: localhost
+          PG_DATABASE: postgres
+          PG_PASSWORD: postgres
+          PG_PORT: ${{ job.services.postgres.ports['5432'] }}
+      - name: Save results
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlc-pg-gen-results
+          path: gen

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sqlc-dev/sqlc
 
-go 1.21
+go 1.22.2
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0


### PR DESCRIPTION
- Updated Go version to 1.22.2 across all GitHub Actions workflows.
- Simplified the testing matrix in `ci.yml` to only include Ubuntu latest.
  This is to reduce the number of CI jobs and speed up the CI runs for the
  fork. The fork is currently being used for use-case that only requires
  linux so the other OSes are not needed and are eating up CI minutes.
- Upgraded PostgreSQL version to 16.2 in `gen.yml`.
