### PR TITLE
feat(sqlc): add streaming support with `:iter` keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,44 @@ sqlc generates **type-safe code** from SQL. Here's how it works:
 
 Check out [an interactive example](https://play.sqlc.dev/) to see it in action, and the [introductory blog post](https://conroy.org/introducing-sqlc) for the motivation behind sqlc.
 
+## Streaming support
+
+This fork contains streaming support using an `:iter` keyword. The keyword is implemented
+for both Go and Kotlin generated code.
+
+Example `:iter` query:
+
+```
+-- name: StreamAuthors :iter
+SELECT * from authors;
+```
+
+Will produce query functions like:
+
+`StreamAuthors(ctx context.Context, iter func(author Author) error) error`
+
+The iter function will be called for each row in the sql result. You are responsible for
+the actual streaming within the passed function. Example:
+
+```
+w := initSomeWriter()
+iter := func(author Author) error {
+    err = w.Write(author)
+    if err != nil {
+        return err
+    }
+    return nil
+}
+
+err := queries.StreamAuthors(ctx, iter)
+```
+
+Also note that if the iter function return an error, the streaming query will close and return the error.
+
+### Building this fork
+
+Clone and run `CGO_ENABLED=0 go build ./cmd/sqlc/main.go` from the project root.
+
 ## Overview
 
 - [Documentation](https://docs.sqlc.dev)

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -271,6 +271,7 @@ type Query struct {
 
 func (q Query) hasRetType() bool {
 	scanned := q.Cmd == metadata.CmdOne || q.Cmd == metadata.CmdMany ||
+		q.Cmd == metadata.CmdIter ||
 		q.Cmd == metadata.CmdBatchMany || q.Cmd == metadata.CmdBatchOne
 	return scanned && !q.Ret.isEmpty()
 }

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -333,6 +333,7 @@ var cmdReturnsData = map[string]struct{}{
 	metadata.CmdBatchMany: {},
 	metadata.CmdBatchOne:  {},
 	metadata.CmdMany:      {},
+	metadata.CmdIter:      {},
 	metadata.CmdOne:       {},
 }
 

--- a/internal/codegen/golang/templates/pgx/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/interfaceCode.tmpl
@@ -20,6 +20,15 @@
             {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
         {{- end}}
+        {{- if and (eq .Cmd ":iter") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, db DBTX, iter func({{.Ret.Name}} {{.Ret.DefineType}}) error, {{.Arg.Pair}}) (error)
+        {{- else if eq .Cmd ":iter" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, iter func({{.Ret.Name}} {{.Ret.DefineType}}) error, {{.Arg.Pair}}) (error)
+        {{- end}}
         {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
             {{range .Comments}}//{{.}}
             {{end -}}

--- a/internal/codegen/golang/templates/stdlib/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/interfaceCode.tmpl
@@ -20,6 +20,15 @@
             {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
         {{- end}}
+        {{- if and (eq .Cmd ":iter") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, db DBTX, iter func({{.Ret.Name}} {{.Ret.DefineType}}) error, {{.Arg.Pair}}) (error)
+        {{- else if eq .Cmd ":iter"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, iter func({{.Ret.Name}} {{.Ret.DefineType}}) error, {{.Arg.Pair}}) (error)
+        {{- end}}
         {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
             {{range .Comments}}//{{.}}
             {{end -}}

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -63,6 +63,39 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 }
 {{end}}
 
+{{if eq .Cmd ":iter"}}
+{{range .Comments}}//{{.}}
+{{end -}}
+func (q *Queries) {{.MethodName}}(ctx context.Context, iter func({{.Ret.Name}} {{.Ret.Type}}) error, {{.Arg.Pair}}) error {
+  	{{- if $.EmitPreparedQueries}}
+	rows, err := q.query(ctx, q.{{.FieldName}}, {{.ConstantName}}, {{.Arg.Params}})
+  	{{- else}}
+	rows, err := q.db.QueryContext(ctx, {{.ConstantName}}, {{.Arg.Params}})
+  	{{- end}}
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var {{.Ret.Name}} {{.Ret.Type}}
+		if err := rows.Scan({{.Ret.Scan}}); err != nil {
+			return err
+		}
+		err = iter(i)
+		if err != nil {
+			return err
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+{{end}}
+
 {{if eq .Cmd ":exec"}}
 {{range .Comments}}//{{.}}
 {{end -}}

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -27,6 +27,7 @@ const (
 	CmdExecRows   = ":execrows"
 	CmdExecLastId = ":execlastid"
 	CmdMany       = ":many"
+	CmdIter       = ":iter"
 	CmdOne        = ":one"
 	CmdCopyFrom   = ":copyfrom"
 	CmdBatchExec  = ":batchexec"
@@ -93,7 +94,7 @@ func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string
 			part = part[:len(part)-1] // removes the trailing "*/" element
 		}
 		if len(part) == 3 {
-			return "", "", fmt.Errorf("missing query type [':one', ':many', ':exec', ':execrows', ':execlastid', ':execresult', ':copyfrom', 'batchexec', 'batchmany', 'batchone']: %s", line)
+			return "", "", fmt.Errorf("missing query type [':one', ':many', ':iter', ':exec', ':execrows', ':execlastid', ':execresult', ':copyfrom', 'batchexec', 'batchmany', 'batchone']: %s", line)
 		}
 		if len(part) != 4 {
 			return "", "", fmt.Errorf("invalid query comment: %s", line)
@@ -101,7 +102,7 @@ func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string
 		queryName := part[2]
 		queryType := strings.TrimSpace(part[3])
 		switch queryType {
-		case CmdOne, CmdMany, CmdExec, CmdExecResult, CmdExecRows, CmdExecLastId, CmdCopyFrom, CmdBatchExec, CmdBatchMany, CmdBatchOne:
+		case CmdOne, CmdMany, CmdIter, CmdExec, CmdExecResult, CmdExecRows, CmdExecLastId, CmdCopyFrom, CmdBatchExec, CmdBatchMany, CmdBatchOne:
 		default:
 			return "", "", fmt.Errorf("invalid query type: %s", queryType)
 		}


### PR DESCRIPTION
Having a look at Øyvind Størkersen's iteration branch.

It adds a template to support `:iter` keyword that allows functions to be
generated that stream query results row by row, handling each with a
user-defined function.
